### PR TITLE
Remove/Mark revised meta

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,13 @@ A collection of HTML head elements.
 <meta http-equiv="Cache-Control" content="no-cache">
 ```
 
+### Deprecated/Legacy
+Below are the meta tags which are either deprecated or not supported anymore:
+
+```
+<meta name="revised" content="Sunday, July 18th, 2010, 5:15 pm">
+```
+
 ## Link Element
 
 ``` html

--- a/README.md
+++ b/README.md
@@ -28,7 +28,6 @@ A collection of HTML head elements.
 <meta name="googlebot" content="index,follow">
 <meta name="google" content="nositelinkssearchbox">
 <meta name="google-site-verification" content="verification_token">
-<meta name="revised" content="Sunday, July 18th, 2010, 5:15 pm">
 <meta name="abstract" content="">
 <meta name="topic" content="">
 <meta name="summary" content="">


### PR DESCRIPTION
Revised meta has been removed from HTML5 according to [this stackOverflow question](http://stackoverflow.com/questions/33889445/is-html-meta-name-revised-valid-or-even-used)

And these links:
- https://wiki.whatwg.org/wiki/MetaExtensions
- http://stackoverflow.com/questions/16171686/list-of-standard-w3c-meta-tags/16207631#16207631

So I think it would be interesting to either remove it from the list, or create a "deprecated" section where we can mark non supported tags.
