### PR TITLE
Update no-referrer example to use 'non-deprecated' value

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ Below are the essential tags for basic, minimalist websites:
 <meta name="rating" content="General">
 
 <!-- Allows control over how referrer information is passed -->
-<meta name="referrer" content="never">
+<meta name="referrer" content="no-referrer">
 
 <!-- Disable automatic detection and formatting of possible phone numbers -->
 <meta name="format-detection" content="telephone=no">


### PR DESCRIPTION
`content="never"` for the "referrer" meta tag is deprecated, according to https://developer.mozilla.org/en/docs/Web/HTML/Element/meta (apologies, not sure how to link to specific section, so you'd have to `ctrl-f` for "referrer"):

```
Note: Some browsers support keywords always, default, and never for referrer.
These values are deprecated.
```