### PR TITLE
Improve contribution guidelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -640,7 +640,15 @@ Example:
 
 ## Contributing
 
-Open an issue or a pull request to suggest changes or additions.
+**Open an issue or a pull request to suggest changes or additions.**
+
+### Guide
+
+The **HEAD** repository consists of two branches:
+
+#### 1. `master`
+
+This branch consists of the `README.md` file that is automatically reflected on the [\<head> Cheat Sheet](http://gethead.info/) website. All changes to the content of the cheat sheet as such should be directed to this file.
 
 Please follow these steps for pull requests:
 
@@ -648,6 +656,12 @@ Please follow these steps for pull requests:
 - Use double quotes on attributes
 - Don't include a trailing slash in self-closing elements — the HTML5 spec says they're optional
 - Consider including a link to documentation that supports your change
+
+#### 2. `gh-pages`
+
+This branch is responsible for the [\<head> Cheat Sheet](http://gethead.info/) website. We use [Jekyll](https://jekyllrb.com/) to deploy the `README.md` Markdown file through [GitHub Pages](https://pages.github.com/). All website related modifications must be directed here.
+
+You might want to go through the [Jekyll Docs](https://jekyllrb.com/docs/home/) and understand how Jekyll works before working on this branch.
 
 ### Contributors
 


### PR DESCRIPTION
The previous contribution guidelines seemed to be quite vague with regard to the Jekyll based [<head> Cheat Sheet](http://gethead.info/) website as stated in #158.

These new guidelines help contributors understand how to contribute to the website too.