### PR TITLE
match second instance of viewport meta

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Below are the essential tags for basic, minimalist websites:
 ```html
 <meta charset="utf-8">
 <meta http-equiv="x-ua-compatible" content="ie=edge">
-<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <!-- The above 3 meta tags *must* come first in the head; any other head content must come *after* these tags -->
 <title>Page Title</title>
 ```


### PR DESCRIPTION
the viewport meta is listed in the essential tags area, and then again in the Meta listing.

In the Meta listing, it has the shrinl-to-fit=no, per necessity for iOS9 devices.

Adding the shrink-to-fit to the first instance of the viewport meta to keep things consistent / not promote a version of the tag that won’t take iOS9 into account.