### PR TITLE
noodp no longer necessary

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Below are the essential tags for basic, minimalist websites:
 <meta name="description" content="A description of the page">
 
 <!-- Control the behavior of search engine crawling and indexing -->
-<meta name="robots" content="index,follow,noodp"><!-- All Search Engines -->
+<meta name="robots" content="index,follow"><!-- All Search Engines -->
 <meta name="googlebot" content="index,follow"><!-- Google Specific -->
 
 <!-- Tells Google not to show the sitelinks search box -->


### PR DESCRIPTION
> As of Mar 17, 2017, dmoz.org is no longer available.

_[DMOZ's official website](http://www.dmoz.org/)_