### PR TITLE
added http-equiv=refresh meta for development purposes

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,9 @@ Below are the essential tags for basic, minimalist websites:
 <!-- Specifies the page to appear in a specific frame -->
 <meta http-equiv="Window-Target" content="_value">
 
+<!-- Instruct the browser to refresh every three seconds -->
+<meta http-equiv="refresh" content="3">
+
 <!-- Geo tags -->
 <meta name="ICBM" content="latitude, longitude">
 <meta name="geo.position" content="latitude;longitude">


### PR DESCRIPTION
I just found a meta that is really useful for development purposes, with `<meta http-equiv="refresh" content="1">` every time you save on your code editor after one second your page will refresh displaying the changes made.  

This meta should be removed when the project goes to production.

Source: https://code.tutsplus.com/tutorials/4-ways-to-auto-refresh-your-browser-when-designing-new-sites--net-13299