### PR TITLE
Update script tag with defer

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,11 +82,13 @@ Valid `<head>` elements include `meta`, `link`, `title`, `style`, `script`, `nos
   /* ... */
 </style>
 
-<!-- JavaScript & No-JavaScript tags -->
-<script src="script.js"></script>
+<!-- JavaScript files -->
+<script src="script.js" defer></script>
+<!-- Inline JavaScript (attention: causes render blocking) -->
 <script>
   // function(s) go here
 </script>
+<!-- No-JavaScript tag -->
 <noscript>
   <!-- No JS alternative -->
 </noscript>


### PR DESCRIPTION
- Adding `defer` boolean attribute to the script tag. Without `defer` the script will block DOM parsing/rendering which slows down the page
- Added a comment to the script tag: Has to be used with caution because it also blocks DOM rendering