### PR TITLE
Fix Pinterest Help Center link

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,7 +339,7 @@ If you embed tweets in your website, Twitter can use information from your site 
 
 ### Pinterest
 
-Pinterest lets you prevent people from saving things from your website, according [to their help center](https://help.pinterest.com/en/articles/prevent-people-saving-things-pinterest-your-site). The `description` is optional.
+Pinterest lets you prevent people from saving things from your website, according [to their help center](https://help.pinterest.com/en/business/article/prevent-saves-to-pinterest-from-your-site). The `description` is optional.
 
 ```html
 <meta name="pinterest" content="nopin" description="Sorry, you can't save from my website!">


### PR DESCRIPTION
Pinterest has changed their Help Center organisation, so the link to the nopin meta tag article died.