### PR TITLE
Add og:image:alt and twitter:image:alt

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,6 +286,7 @@ These elements provide information for how a document should be perceived, and r
 <meta property="og:type" content="website">
 <meta property="og:title" content="Content Title">
 <meta property="og:image" content="https://example.com/image.jpg">
+<meta property="og:image:alt" content="A description of what is in the image (not a caption)">
 <meta property="og:description" content="Description Here">
 <meta property="og:site_name" content="Site Name">
 <meta property="og:locale" content="en_US">
@@ -306,6 +307,7 @@ These elements provide information for how a document should be perceived, and r
 <meta name="twitter:title" content="Content Title">
 <meta name="twitter:description" content="Content description less than 200 characters">
 <meta name="twitter:image" content="https://example.com/image.jpg">
+<meta name="twitter:image:alt" content="A text description of the image conveying the essential nature of an image to users who are visually impaired. Maximum 420 characters.">
 ```
 
 - 📖 [Getting started with cards — Twitter Developers](https://dev.twitter.com/cards/getting-started)


### PR DESCRIPTION
When using `og:image` you should always also use `og:image:alt` (A description of what is in the image (not a caption)) to conve the essential nature of the image to users who are visually impaired.

The same is true for `twitter:image`, where the property is `twitter:image:alt`