### PR TITLE
Add viewport-fit=cover

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ These elements provide information for how a document should be perceived, and r
   Any other head element should come *after* these tags.
 -->
 <meta charset="utf-8">
-<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
 
 <!--
   Allows control over where resources are loaded from.


### PR DESCRIPTION
the `viewport-fit=cover` is a viewport meta value that enable the usage of [environment variables `env()`](https://developer.mozilla.org/en-US/docs/Web/CSS/env) inside CSS, in order to handle rounded display and notches (margin and paddings). This value is currently supported by Chrome and Safari mobile, and i think it should be always present to handle today's mobile devices screens.

**EXAMPLE**
```html
<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
```

**CSS SPEC**
https://drafts.csswg.org/css-round-display/

**ADDITIONAL INFO HERE**
https://www.codewall.co.uk/css-env-variables-for-todays-edge-screen-devices/