### PR TITLE
Add Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+**
+
+!_*
+!img
+!index.md
+!main.scss
+!favicon*
+!README.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM jekyll/jekyll:minimal AS builder
+COPY . .
+RUN ["jekyll", "build"]
+
+FROM nginx:alpine AS runner
+COPY --from=builder /srv/jekyll/_site /usr/share/nginx/html


### PR DESCRIPTION
Added a Dockerfile so `HEAD` could be deployed as a container!

To build, run:

`docker build -t head .`

To start serving the website:

`docker run -d -p 8080:80 head`.

Now you can go to http://localhost:8080/ and browse HEAD!