### PR TITLE
update schema.org links

### DIFF
--- a/README.md
+++ b/README.md
@@ -347,7 +347,7 @@ If you embed tweets in your website, Twitter can use information from your site 
 **Note:** These meta tags require the `itemscope` and `itemtype` attributes to be added to the `<html>` tag.
 
 - 📖 [Getting Started - schema.org](https://schema.org/docs/gs.html)
-- 🛠 Test your page with the [Structured Data Testing Tool](https://developers.google.com/structured-data/testing-tool/)
+- 🛠 Test your page with the [Rich Results Test](https://search.google.com/test/rich-results)
 
 ### Pinterest
 

--- a/README.md
+++ b/README.md
@@ -346,6 +346,7 @@ If you embed tweets in your website, Twitter can use information from your site 
 
 **Note:** These meta tags require the `itemscope` and `itemtype` attributes to be added to the `<html>` tag.
 
+- 📖 [Getting Started - schema.org](https://schema.org/docs/gs.html)
 - 🛠 Test your page with the [Structured Data Testing Tool](https://developers.google.com/structured-data/testing-tool/)
 
 ### Pinterest


### PR DESCRIPTION
- added link to the schema.org getting started page to add more context
- replaced the Structured Data Testing Tool with the Rich Results Test because [the Structured Data Testing Tool is in the process of being deprecated and replaced by the Rich Results Test ](https://webmasters.googleblog.com/2020/07/rich-results-test-out-of-beta.html)