### PR TITLE
Updating applinks url

### DIFF
--- a/README.md
+++ b/README.md
@@ -555,7 +555,7 @@ Minimum required xml markup for `browserconfig.xml`:
 <meta property="al:web:url" content="https://applinks.org/documentation">
 ```
 
-- 📖 [App Links](https://applinks.org/documentation/)
+- 📖 [App Links](https://developers.facebook.com/docs/applinks)
 
 **[⬆ back to top](#table-of-contents)**
 


### PR DESCRIPTION
Hey @joshbuchea 

the URL below the Applinks gave me an SSL error and then redirected me to a page on Facebook Dev sites. Here is a PR to go directly there in case you want to update it.

Cheers,
Peter