### PR TITLE
update schema.org section

### DIFF
--- a/README.md
+++ b/README.md
@@ -337,6 +337,8 @@ If you embed tweets in your website, Twitter can use information from your site 
 
 ### Schema.org
 
+#### Microdata
+
 ```html
 <html lang="" itemscope itemtype="https://schema.org/Article">
     <head>
@@ -348,6 +350,33 @@ If you embed tweets in your website, Twitter can use information from your site 
 ```
 
 **Note:** These meta tags require the `itemscope` and `itemtype` attributes to be added to the `<html>` tag.
+
+#### JSON-LD
+
+```html
+<!-- Modified example from https://developers.google.com/search/docs/data-types/article -->
+<html>
+  <head>
+    <title>Article Headline</title>
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "Article",
+      "author": {
+        "@type": "Person",
+        "name": "Your Name"
+      },
+      "publisher": {
+        "@type": "Organization",
+        "name": "Your Organization"
+      },
+      "headline": "Article Headline",
+      "image": "https://example.com/image.jpg",
+      "datePublished": "2020-02-05T08:00:00+08:00",
+      "dateModified": "2020-03-05T09:20:00+08:00"
+    }
+    </script>
+```
 
 - 📖 [Getting Started - schema.org](https://schema.org/docs/gs.html)
 - 🛠 Test your page with the [Rich Results Test](https://search.google.com/test/rich-results)

--- a/README.md
+++ b/README.md
@@ -379,6 +379,8 @@ If you embed tweets in your website, Twitter can use information from your site 
 ```
 
 - 📖 [Getting Started - schema.org](https://schema.org/docs/gs.html)
+- 📖 [Google - Structured Data](https://developers.google.com/search/docs/guides/intro-structured-data)
+- 📖 [Bing - Structured Data](https://www.bing.com/webmaster/help/marking-up-your-site-with-structured-data-3a93e731)
 - 🛠 Test your page with the [Rich Results Test](https://search.google.com/test/rich-results)
 
 ### Pinterest


### PR DESCRIPTION
- added sub headers for Microdata and JSON-LD
- added schema.org JSON-LD format which is an alternative to the Microdata format and is [recommended by Google](https://developers.google.com/search/docs/guides/intro-structured-data#structured-data-format)
- added links to Google and Bing structured data documentations for further reading
