### PR TITLE
Removed deprecated rel types 'first' and 'last'

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,9 +228,7 @@ These elements provide information for how a document should be perceived, and r
 <!-- Provides a self reference - useful when the document has multiple possible references -->
 <link rel="self" type="application/atom+xml" href="https://example.com/atom.xml">
 
-<!-- The first, last, previous, and next documents in a series of documents, respectively -->
-<link rel="first" href="https://example.com/article/">
-<link rel="last" href="https://example.com/article/?page=42">
+<!-- The previous, and next documents in a series of documents, respectively -->
 <link rel="prev" href="https://example.com/article/?page=1">
 <link rel="next" href="https://example.com/article/?page=3">
 


### PR DESCRIPTION
According to https://developer.mozilla.org/en-US/docs/Web/HTML/Link_types `first` and `last` are deprecated.
They are also no longer listed on https://html.spec.whatwg.org/multipage/links.html#linkTypes

A discussion  about this can be found on https://stackoverflow.com/q/42841618/534883