### PR TITLE
Add fediverse:creator

### DIFF
--- a/README.md
+++ b/README.md
@@ -401,6 +401,16 @@ Users share web pages to qq wechat will have a formatted message
 
 **[⬆ back to top](#table-of-contents)**
 
+### Fediverse
+
+Some Fediverse software such as Mastodon allow you to put your Fediverse handle in a meta tag which will show up in embeds to your website. In addition to the tag you will also need to add your domain to the list of allowed websites in "Settings -> Public profile -> Verification -> Author attribution" (for Mastodon).
+
+```html
+<meta name="fediverse:creator" content="@handle@example.org">
+```
+
+**[⬆ back to top](#table-of-contents)**
+
 ## Browsers / Platforms
 
 ### Apple iOS


### PR DESCRIPTION
Add info about the `fediverse:creator` tag used by Mastodon (and probably other Fediverse software at this point) to add a link to an author's Fediverse handle in posted link embeds.