### PR TITLE
fix: remove nation flags before translations

### DIFF
--- a/README.md
+++ b/README.md
@@ -596,16 +596,16 @@ Minimum required xml markup for `browserconfig.xml`:
 
 ## 🌐 Translations
 
-- 🇮🇩 [Bahasa](https://github.com/rijdz/HEAD)
-- 🇧🇷 [Brazilian Portuguese](https://github.com/Webschool-io/HEAD)
-- 🇨🇳 [Chinese (Simplified)](https://github.com/Amery2010/HEAD)
-- 🇩🇪 [German](https://github.com/Shidigital/HEAD)
-- 🇮🇹 [Italian](https://github.com/Fakkio/HEAD)
-- 🇯🇵 [Japanese](https://coliss.com/articles/build-websites/operation/work/collection-of-html-head-elements.html)
-- 🇰🇷 [Korean](https://github.com/Lutece/HEAD)
-- 🇷🇺 [Russian/Русский](https://github.com/Konfuze/HEAD)
-- 🇪🇸 [Spanish](https://github.com/alvaroadlf/HEAD)
-- 🇹🇷 [Turkish/Türkçe](https://github.com/mkg0/HEAD)
+- [Bahasa](https://github.com/rijdz/HEAD)
+- [Brazilian Portuguese](https://github.com/Webschool-io/HEAD)
+- [Chinese (Simplified)](https://github.com/Amery2010/HEAD)
+- [German](https://github.com/Shidigital/HEAD)
+- [Italian](https://github.com/Fakkio/HEAD)
+- [Japanese](https://coliss.com/articles/build-websites/operation/work/collection-of-html-head-elements.html)
+- [Korean](https://github.com/Lutece/HEAD)
+- [Russian/Русский](https://github.com/Konfuze/HEAD)
+- [Spanish](https://github.com/alvaroadlf/HEAD)
+- [Turkish/Türkçe](https://github.com/mkg0/HEAD)
 
 **[⬆ back to top](#table-of-contents)**
 


### PR DESCRIPTION
Flags are considered as the symbol of a nation, instead of a language. Use flags to represent languages makes people feel offended sometimes (verbally or politically). What's more, some languages are widely spoken around the world. For instance, Chinese is spoken in China, Singapore, Chinese Hong Kong, etc, so do English, choosing only one flag to represent these languages may offend speakers in other countries. 

The PR removes flags before the translations. 

https://www.flagsarenotlanguages.com/blog/why-flags-do-not-represent-language/