### PR TITLE
Add copy-to-clipboard button to code blocks

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -27,6 +27,12 @@
     </script>
     <script>
       // copy to clipboard button on code blocks
+      var statusRegion = document.createElement('div');
+      statusRegion.className = 'visually-hidden';
+      statusRegion.setAttribute('aria-live', 'polite');
+      statusRegion.setAttribute('role', 'status');
+      document.body.appendChild(statusRegion);
+
       var preBlocks = document.querySelectorAll('pre');
       var preBlocksLength = preBlocks.length;
       var j;
@@ -37,16 +43,17 @@
           button.className = 'copy-btn';
           button.type = 'button';
           button.textContent = 'Copy';
-          button.setAttribute('aria-label', 'Copy code to clipboard');
     
           button.addEventListener('click', function () {
             var code = pre.querySelector('code');
             var text = code ? code.innerText : pre.innerText;
             navigator.clipboard.writeText(text).then(function () {
               button.textContent = 'Copied';
+              statusRegion.textContent = 'Copied to clipboard';
               setTimeout(function () { button.textContent = 'Copy'; }, 1500);
             }).catch(function () {
               button.textContent = 'Failed';
+              statusRegion.textContent = 'Copy to clipboard failed';
               setTimeout(function () { button.textContent = 'Copy'; }, 1500);
             });
           });

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -30,7 +30,7 @@
       // copy to clipboard button on code blocks
       if (navigator.clipboard && typeof navigator.clipboard.writeText === 'function') {
         var statusRegion = document.querySelector('[aria-live="polite"][role="status"]');
-        var preBlocks = document.querySelectorAll('pre');
+        var preBlocks = document.querySelectorAll('pre.highlight');
         var preBlocksLength = preBlocks.length;
         var j;
         for (j = 0; j < preBlocksLength; j++) {
@@ -50,10 +50,12 @@
               var text = code ? (code.textContent || '') : (pre.textContent || '');
               navigator.clipboard.writeText(text).then(function () {
                 button.textContent = 'Copied';
+                statusRegion.textContent = '';
                 statusRegion.textContent = 'Copied to clipboard';
                 setTimeout(function () { button.textContent = 'Copy'; }, 1500);
               }).catch(function () {
                 button.textContent = 'Failed';
+                statusRegion.textContent = '';
                 statusRegion.textContent = 'Copy to clipboard failed';
                 setTimeout(function () { button.textContent = 'Copy'; }, 1500);
               });

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -11,7 +11,8 @@
         {{ content }}
       </div>
     </div>
-
+    <div class="visually-hidden" aria-live="polite" role="status"></div>
+    
     <script>
       // open external links in new tab
       var links = document.links;
@@ -27,39 +28,40 @@
     </script>
     <script>
       // copy to clipboard button on code blocks
-      var statusRegion = document.createElement('div');
-      statusRegion.className = 'visually-hidden';
-      statusRegion.setAttribute('aria-live', 'polite');
-      statusRegion.setAttribute('role', 'status');
-      document.body.appendChild(statusRegion);
+      if (navigator.clipboard && typeof navigator.clipboard.writeText === 'function') {
+        var statusRegion = document.querySelector('[aria-live="polite"][role="status"]');
+        var preBlocks = document.querySelectorAll('pre');
+        var preBlocksLength = preBlocks.length;
+        var j;
+        for (j = 0; j < preBlocksLength; j++) {
+          (function (pre) {
+            var wrapper = document.createElement('div');
+            wrapper.className = 'pre-wrapper';
+            pre.parentNode.insertBefore(wrapper, pre);
+            wrapper.appendChild(pre);
 
-      var preBlocks = document.querySelectorAll('pre');
-      var preBlocksLength = preBlocks.length;
-      var j;
-      for (j = 0; j < preBlocksLength; j++) {
-        (function (pre) {
-          if (!navigator.clipboard || typeof navigator.clipboard.writeText !== 'function') return;
-          var button = document.createElement('button');
-          button.className = 'copy-btn';
-          button.type = 'button';
-          button.textContent = 'Copy';
-    
-          button.addEventListener('click', function () {
-            var code = pre.querySelector('code');
-            var text = code ? code.innerText : pre.innerText;
-            navigator.clipboard.writeText(text).then(function () {
-              button.textContent = 'Copied';
-              statusRegion.textContent = 'Copied to clipboard';
-              setTimeout(function () { button.textContent = 'Copy'; }, 1500);
-            }).catch(function () {
-              button.textContent = 'Failed';
-              statusRegion.textContent = 'Copy to clipboard failed';
-              setTimeout(function () { button.textContent = 'Copy'; }, 1500);
+            var button = document.createElement('button');
+            button.className = 'copy-btn';
+            button.type = 'button';
+            button.textContent = 'Copy';
+
+            button.addEventListener('click', function () {
+              var code = pre.querySelector('code');
+              var text = code ? (code.textContent || '') : (pre.textContent || '');
+              navigator.clipboard.writeText(text).then(function () {
+                button.textContent = 'Copied';
+                statusRegion.textContent = 'Copied to clipboard';
+                setTimeout(function () { button.textContent = 'Copy'; }, 1500);
+              }).catch(function () {
+                button.textContent = 'Failed';
+                statusRegion.textContent = 'Copy to clipboard failed';
+                setTimeout(function () { button.textContent = 'Copy'; }, 1500);
+              });
             });
-          });
-    
-          pre.appendChild(button);
-        })(preBlocks[j]);
+
+            wrapper.appendChild(button);
+          })(preBlocks[j]);
+        }
       }
     </script>
     {% include analytics.html %}

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -32,6 +32,7 @@
       var j;
       for (j = 0; j < preBlocksLength; j++) {
         (function (pre) {
+          if (!navigator.clipboard || typeof navigator.clipboard.writeText !== 'function') return;
           var button = document.createElement('button');
           button.className = 'copy-btn';
           button.type = 'button';

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -25,6 +25,35 @@
         }
       }
     </script>
+    <script>
+      // copy to clipboard button on code blocks
+      var preBlocks = document.querySelectorAll('pre');
+      var preBlocksLength = preBlocks.length;
+      var j;
+      for (j = 0; j < preBlocksLength; j++) {
+        (function (pre) {
+          var button = document.createElement('button');
+          button.className = 'copy-btn';
+          button.type = 'button';
+          button.textContent = 'Copy';
+          button.setAttribute('aria-label', 'Copy code to clipboard');
+    
+          button.addEventListener('click', function () {
+            var code = pre.querySelector('code');
+            var text = code ? code.innerText : pre.innerText;
+            navigator.clipboard.writeText(text).then(function () {
+              button.textContent = 'Copied';
+              setTimeout(function () { button.textContent = 'Copy'; }, 1500);
+            }).catch(function () {
+              button.textContent = 'Failed';
+              setTimeout(function () { button.textContent = 'Copy'; }, 1500);
+            });
+          });
+    
+          pre.appendChild(button);
+        })(preBlocks[j]);
+      }
+    </script>
     {% include analytics.html %}
   </body>
 </html>

--- a/main.css
+++ b/main.css
@@ -319,7 +319,7 @@ pre > code:focus {
 } */
 
 /* Code */
-/* .highlight .hll { background-color: #ffc; 
+/* .highlight .hll { background-color: #ffc;
 .highlight .c { color: #999; }
 .highlight .err { color: #a00; background-color: #faa }
 .highlight .k { color: #069; }
@@ -730,4 +730,10 @@ pre:hover .copy-btn,
 
 .copy-btn:hover {
   background: rgba(171, 178, 191, 0.1);
+}
+
+@media (hover: none) {
+  .copy-btn {
+    opacity: 1;
+  }
 }

--- a/main.css
+++ b/main.css
@@ -721,11 +721,13 @@ pre.highlight {
   opacity: 0;
   text-align: center;
   transition: opacity 0.15s ease-in-out;
+  pointer-events: none;
 }
 
 .pre-wrapper:hover .copy-btn,
 .copy-btn:focus {
   opacity: 1;
+  pointer-events: auto;
 }
 
 .copy-btn:hover {
@@ -735,6 +737,7 @@ pre.highlight {
 @media (hover: none) {
   .copy-btn {
     opacity: 1;
+    pointer-events: auto;
   }
 }
 

--- a/main.css
+++ b/main.css
@@ -701,7 +701,7 @@ pre.highlight {
 }
 
 /* Copy to clipboard button */
-pre {
+.pre-wrapper {
   position: relative;
 }
 
@@ -723,7 +723,7 @@ pre {
   transition: opacity 0.15s ease-in-out;
 }
 
-pre:hover .copy-btn,
+.pre-wrapper:hover .copy-btn,
 .copy-btn:focus {
   opacity: 1;
 }
@@ -746,4 +746,3 @@ pre:hover .copy-btn,
   position: absolute;
   white-space: nowrap;
 }
-

--- a/main.css
+++ b/main.css
@@ -737,3 +737,13 @@ pre:hover .copy-btn,
     opacity: 1;
   }
 }
+
+.visually-hidden {
+  clip-path: inset(50%);
+  height: 1px;
+  width: 1px;
+  overflow: hidden;
+  position: absolute;
+  white-space: nowrap;
+}
+

--- a/main.css
+++ b/main.css
@@ -699,3 +699,35 @@ pre.highlight {
 .highlight .gi {
   color: #a6e22e;
 }
+
+/* Copy to clipboard button */
+pre {
+  position: relative;
+}
+
+.copy-btn {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  min-width: 60px;
+  padding: 4px 10px;
+  font-family: inherit;
+  font-size: 12px;
+  color: #abb2bf;
+  background: transparent;
+  border: 1px solid #abb2bf;
+  border-radius: 4px;
+  cursor: pointer;
+  opacity: 0;
+  text-align: center;
+  transition: opacity 0.15s ease-in-out;
+}
+
+pre:hover .copy-btn,
+.copy-btn:focus {
+  opacity: 1;
+}
+
+.copy-btn:hover {
+  background: rgba(171, 178, 191, 0.1);
+}


### PR DESCRIPTION
Closes #130

Adds a copy-to-clipboard button to each code block.

## Implementation

- Vanilla JS in `_layouts/default.html`, matching the existing inline-script convention
- Native `navigator.clipboard.writeText()` instead of clipboard.js to avoid a dependency
- Styling in `main.css` reuses the One Dark palette already in the file
- Button hidden by default, revealed on `pre:hover` or `.copy-btn:focus`

## Testing

Verified in the browser console against https://htmlhead.dev. Buttons render, copy works, label cycles correctly.